### PR TITLE
Submodule warnings/misc

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "lammps"]
 	path = lammps
 	url = https://github.com/lammps/lammps
+	shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "lammps"]
 	path = lammps
 	url = https://github.com/lammps/lammps
-	shallow = true

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ If you just want to see the rust signatures for the bindings, you can also gener
 ```
 git clone https://github.com/ExpHP/lammps-sys
 cd lammps-sys
+git submodule update --init
 cargo doc --open
 ```
 
@@ -85,6 +86,8 @@ For an easier time diagnosing building/linking issues, you can clone this repo a
 ```sh
 $ git clone https://github.com/ExpHP/lammps-sys
 $ cd lammps-sys
+$ # note: submodule update is only needed when building lammps from source
+$ git submodule update --init
 $ cargo run --example=link-test
 LAMMPS (31 Mar 2017)
 Total wall time: 0:00:00

--- a/build/build.rs
+++ b/build/build.rs
@@ -177,7 +177,7 @@ pub(crate) fn lammps_dotgit_dir() -> BoxResult<Option<PathDir>> {
 /// Path to the directory within the lammps submodule that contains CMakeLists.txt.
 pub(crate) fn lammps_cmake_root() -> BoxResult<PathDir> {
     // NOTE: This first line will succeed even if the submodule isn't initialized because
-    //       git still will have created an empty directory.
+    //       git still will have created an empty lammps/ directory.
     let cmake_root = lammps_repo_dir_build_copy()?.join("cmake");
     Ok(PathDir::new(cmake_root.canonicalize().map_err(|_| {
         format!("could not resolve {:?}, you probably forgot to `git submodule update --init`", cmake_root)

--- a/build/build.rs
+++ b/build/build.rs
@@ -176,8 +176,9 @@ pub(crate) fn lammps_dotgit_dir() -> BoxResult<Option<PathDir>> {
 
 /// Path to the directory within the lammps submodule that contains CMakeLists.txt.
 pub(crate) fn lammps_cmake_root() -> BoxResult<PathDir> {
-    Ok(PathDir::new(lammps_repo_dir_build_copy()?.join("cmake").canonicalize().map_err(|_| {
-        format!("could not resolve {:?}/cmake, you probably forgot to `git submodule update --init`", lammps_repo_dir())
+    let cmake_root = lammps_repo_dir_build_copy()?.join("cmake");
+    Ok(PathDir::new(cmake_root.canonicalize().map_err(|_| {
+        format!("could not resolve {:?}, you probably forgot to `git submodule update --init`", cmake_root)
     })?)?)
 }
 

--- a/build/build.rs
+++ b/build/build.rs
@@ -107,7 +107,9 @@ pub(crate) fn lammps_dotgit_dir() -> BoxResult<Option<PathDir>> {
 
 /// Path to the directory within the lammps submodule that contains CMakeLists.txt.
 pub(crate) fn lammps_cmake_root() -> BoxResult<PathDir> {
-    Ok(PathDir::new(lammps_repo_dir().join("cmake").canonicalize()?)?)
+    Ok(PathDir::new(lammps_repo_dir().join("cmake").canonicalize().map_err(|_| {
+        format!("could not resolve {:?}/cmake, you probably forgot to `git submodule update --init`", lammps_repo_dir())
+    })?)?)
 }
 
 // ----------------------------------------------------

--- a/build/build.rs
+++ b/build/build.rs
@@ -178,7 +178,8 @@ pub(crate) fn lammps_dotgit_dir() -> BoxResult<Option<PathDir>> {
 pub(crate) fn lammps_cmake_root() -> BoxResult<PathDir> {
     let cmake_root = lammps_repo_dir_build_copy()?.join("cmake");
     Ok(PathDir::new(cmake_root.canonicalize().map_err(|_| {
-        format!("could not resolve {:?}, you probably forgot to `git submodule update --init`", cmake_root)
+        format!("could not resolve {:?}, you probably forgot to `git submodule update --init`\n"
+                + "note that you might need to run cargo clean after doing so.", cmake_root)
     })?)?)
 }
 

--- a/build/build.rs
+++ b/build/build.rs
@@ -178,8 +178,7 @@ pub(crate) fn lammps_dotgit_dir() -> BoxResult<Option<PathDir>> {
 pub(crate) fn lammps_cmake_root() -> BoxResult<PathDir> {
     let cmake_root = lammps_repo_dir_build_copy()?.join("cmake");
     Ok(PathDir::new(cmake_root.canonicalize().map_err(|_| {
-        format!("could not resolve {:?}, you probably forgot to `git submodule update --init`\n"
-                + "note that you might need to run cargo clean after doing so.", cmake_root)
+        format!("could not resolve {:?}, you probably forgot to `git submodule update --init`", cmake_root)
     })?)?)
 }
 

--- a/build/build.rs
+++ b/build/build.rs
@@ -176,6 +176,8 @@ pub(crate) fn lammps_dotgit_dir() -> BoxResult<Option<PathDir>> {
 
 /// Path to the directory within the lammps submodule that contains CMakeLists.txt.
 pub(crate) fn lammps_cmake_root() -> BoxResult<PathDir> {
+    // NOTE: This first line will succeed even if the submodule isn't initialized because
+    //       git still will have created an empty directory.
     let cmake_root = lammps_repo_dir_build_copy()?.join("cmake");
     Ok(PathDir::new(cmake_root.canonicalize().map_err(|_| {
         format!("could not resolve {:?}, you probably forgot to `git submodule update --init`", cmake_root)


### PR DESCRIPTION
Updated readme and merged warning for when git submodule isn't checked out. The error it threw before was not particularly helpful. Also added `shallow = true` to the lammps submodule, which...may or may not actually help when updating.